### PR TITLE
fix: move chainId intent validation

### DIFF
--- a/packages/solver/internal/actions/handler.go
+++ b/packages/solver/internal/actions/handler.go
@@ -55,10 +55,9 @@ type ActionDefinition struct {
 }
 
 var (
-	errUnsupportedAction  = "unsupported action: %s"
-	errInvalidChainID     = "invalid chain id: %s"
-	errUnsupportedChainID = "unsupported chain id: %s"
-	errFailedOptions      = "failed to get options: %w"
+	errUnsupportedAction = "unsupported action: %s"
+	errInvalidChainID    = "invalid chain id: %s"
+	errFailedOptions     = "failed to get options: %w"
 )
 
 func NewBaseHandler(

--- a/packages/solver/internal/actions/handler.go
+++ b/packages/solver/internal/actions/handler.go
@@ -167,25 +167,6 @@ func (h *BaseHandler) GetSchema(chainId string, from common.Address, search map[
 			return nil, fmt.Errorf(errInvalidChainID, chainId)
 		}
 
-		// TODO: (#475) Why is this needed here? Shouldn't this be handled elsewhere? Not sure if it
-		//       actually should be, but we are really far into the compute process to only
-		//       just now be checking this here. Something earlier should have fired this most
-		//       likely like a provider or something. Even if it is not caught earlier, does
-		//       dealing with this here improve things or does it just bloat this function with
-		//       things that we do not actually need?
-		supported := false
-		for _, supportedChain := range h.protocol.Chains {
-			for _, supportedChainId := range supportedChain.ChainIds {
-				if chainIdInt == supportedChainId {
-					supported = true
-					break
-				}
-			}
-		}
-		if !supported {
-			return nil, fmt.Errorf("chain not supported: %d", chainIdInt)
-		}
-
 		// NOTE: Override the address value so that we utilize the cache from the global state
 		//       instead of using the "from" parameter as a key lookup even when provided if
 		//       the action being queried against only supports global state.

--- a/packages/solver/internal/actions/handler.go
+++ b/packages/solver/internal/actions/handler.go
@@ -22,7 +22,7 @@ type BaseProtocolHandler interface {
 	GetIcon() string
 	GetTags() []string
 	GetActions() []string
-	GetChains() []*references.Network
+	GetChains(chainId string) []*references.Network
 	GetSchema(chainId string, from common.Address, search map[int]string, action string) (*ChainSchema, error)
 	GetSchemas() map[string]ChainSchema
 	GetTransaction(action string, rawInputs json.RawMessage, params HandlerParams) ([]signature.Plug, error)
@@ -140,21 +140,20 @@ func (h *BaseHandler) GetTags() []string {
 	return h.protocol.Tags
 }
 
-func (h *BaseHandler) GetChains(chainId string) ([]*references.Network, error) {
-	chainIdInt, err := strconv.ParseUint(chainId, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf(errInvalidChainID, chainId)
+func (h *BaseHandler) GetChains(chainId string) []*references.Network {
+	if chainId == "" {
+		return h.protocol.Chains
 	}
 
 	for _, chain := range h.protocol.Chains {
 		for _, supportedChainId := range chain.ChainIds {
-			if chainIdInt == supportedChainId {
-				return []*references.Network{chain}, nil
+			if chainId == fmt.Sprint(supportedChainId) {
+				return []*references.Network{chain}
 			}
 		}
 	}
 
-	return nil, fmt.Errorf(errUnsupportedChainID, chainId)
+	return nil
 }
 
 func (h *BaseHandler) GetActions() []string {

--- a/packages/solver/internal/actions/handler.go
+++ b/packages/solver/internal/actions/handler.go
@@ -55,9 +55,10 @@ type ActionDefinition struct {
 }
 
 var (
-	errUnsupportedAction = "unsupported action: %s"
-	errInvalidChainID    = "invalid chain id: %s"
-	errFailedOptions     = "failed to get options: %w"
+	errUnsupportedAction  = "unsupported action: %s"
+	errInvalidChainID     = "invalid chain id: %s"
+	errUnsupportedChainID = "unsupported chain id: %s"
+	errFailedOptions      = "failed to get options: %w"
 )
 
 func NewBaseHandler(
@@ -139,8 +140,21 @@ func (h *BaseHandler) GetTags() []string {
 	return h.protocol.Tags
 }
 
-func (h *BaseHandler) GetChains() []*references.Network {
-	return h.protocol.Chains
+func (h *BaseHandler) GetChains(chainId string) ([]*references.Network, error) {
+	chainIdInt, err := strconv.ParseUint(chainId, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf(errInvalidChainID, chainId)
+	}
+
+	for _, chain := range h.protocol.Chains {
+		for _, supportedChainId := range chain.ChainIds {
+			if chainIdInt == supportedChainId {
+				return []*references.Network{chain}, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf(errUnsupportedChainID, chainId)
 }
 
 func (h *BaseHandler) GetActions() []string {

--- a/packages/solver/internal/api/solver/intent.go
+++ b/packages/solver/internal/api/solver/intent.go
@@ -130,6 +130,28 @@ func (h *Handler) GetIntent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if chainId != "" {
+		chainIdInt, err := strconv.ParseUint(chainId, 10, 64)
+		if err != nil {
+			utils.MakeHttpError(w, fmt.Sprintf("invalid chainId: %s", chainId), http.StatusBadRequest)
+			return
+		}
+
+		supported := false
+		for _, chain := range handler.GetChains() {
+			for _, supportedChainId := range chain.ChainIds {
+				if chainIdInt == supportedChainId {
+					supported = true
+					break
+				}
+			}
+		}
+		if !supported {
+			utils.MakeHttpError(w, fmt.Sprintf("protocol %s does not support chainId %s", protocol, chainId), http.StatusBadRequest)
+			return
+		}
+	}
+
 	if action == "" {
 		var chains []*references.Network
 		for _, chain := range handler.GetChains() {

--- a/packages/solver/internal/api/solver/intent.go
+++ b/packages/solver/internal/api/solver/intent.go
@@ -73,24 +73,8 @@ func (h *Handler) GetIntent(w http.ResponseWriter, r *http.Request) {
 		allSchemas := make(map[string]actions.ProtocolSchema)
 
 		for protocol, handler := range h.Solver.GetProtocols() {
-			if chainId != "" {
-				supportsChain := false
-			chainLoop:
-				for _, chain := range handler.GetChains() {
-					for _, _chainId := range chain.ChainIds {
-						if chainId == fmt.Sprint(_chainId) {
-							supportsChain = true
-							break chainLoop
-						}
-					}
-				}
-				if !supportsChain {
-					continue
-				}
-			}
-
 			var chains []*references.Network
-			for _, chain := range handler.GetChains() {
+			for _, chain := range handler.GetChains(chainId) {
 				chainCopy := *chain
 				chainCopy.References = nil
 				chains = append(chains, &chainCopy)
@@ -130,14 +114,14 @@ func (h *Handler) GetIntent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if action == "" {
-		var chains []*references.Network
-		for _, chain := range handler.GetChains() {
-			chainCopy := *chain
-			chainCopy.References = nil
-			chains = append(chains, &chainCopy)
-		}
+	var chains []*references.Network
+	for _, chain := range handler.GetChains(chainId) {
+		chainCopy := *chain
+		chainCopy.References = nil
+		chains = append(chains, &chainCopy)
+	}
 
+	if action == "" {
 		protocolSchema := actions.ProtocolSchema{
 			Metadata: actions.ProtocolMetadata{
 				Icon:   handler.GetIcon(),
@@ -171,13 +155,6 @@ func (h *Handler) GetIntent(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		utils.MakeHttpError(w, err.Error(), http.StatusBadRequest)
 		return
-	}
-
-	var chains []*references.Network
-	for _, chain := range handler.GetChains() {
-		chainCopy := *chain
-		chainCopy.References = nil
-		chains = append(chains, &chainCopy)
 	}
 
 	protocolSchema := actions.ProtocolSchema{

--- a/packages/solver/internal/api/solver/intent.go
+++ b/packages/solver/internal/api/solver/intent.go
@@ -130,28 +130,6 @@ func (h *Handler) GetIntent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if chainId != "" {
-		chainIdInt, err := strconv.ParseUint(chainId, 10, 64)
-		if err != nil {
-			utils.MakeHttpError(w, fmt.Sprintf("invalid chainId: %s", chainId), http.StatusBadRequest)
-			return
-		}
-
-		supported := false
-		for _, chain := range handler.GetChains() {
-			for _, supportedChainId := range chain.ChainIds {
-				if chainIdInt == supportedChainId {
-					supported = true
-					break
-				}
-			}
-		}
-		if !supported {
-			utils.MakeHttpError(w, fmt.Sprintf("protocol %s does not support chainId %s", protocol, chainId), http.StatusBadRequest)
-			return
-		}
-	}
-
 	if action == "" {
 		var chains []*references.Network
 		for _, chain := range handler.GetChains() {


### PR DESCRIPTION
Feels like the only place to move the chain ID check is into the GetIntent handler, but that bad boy is already pretty fat..

We definitely need to keep the check IMO but I'm leaning towards it making more sense where it is as that's also where we validate that the action exists on the protocol. Not super opinionated on this though. The only way it'd make sense to throw it in the GetIntent handler is if we're willing to break that apart into smaller functions for each of the if cases.