### PR TITLE
fix: standard solver error responses and required from field

### DIFF
--- a/packages/solver/internal/actions/protocol.go
+++ b/packages/solver/internal/actions/protocol.go
@@ -53,7 +53,9 @@ func (p *Protocol) GetSchema(chainId uint64, from common.Address, search map[int
 	}
 
 	if definition.GetOptions() != nil {
-		if !definition.GetIsUserSpecific() {
+		if definition.GetIsUserSpecific() && from == utils.ZeroAddress {
+			return nil, utils.ErrMissingField("from")
+		} else if !definition.GetIsUserSpecific() {
 			from = utils.ZeroAddress
 		}
 

--- a/packages/solver/internal/api/routes/api_key/create.go
+++ b/packages/solver/internal/api/routes/api_key/create.go
@@ -43,15 +43,15 @@ func CreateContext(oc openapi.OperationContext) error {
 func CreateRequest(w http.ResponseWriter, r *http.Request, _ *redis.Client, s *solver.Solver) {
 	var apiKey models.ApiKey
 	if err := json.NewDecoder(r.Body).Decode(&apiKey); err != nil {
-		utils.MakeHttpError(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		utils.RespondWithError(w, utils.ErrInternal("failed to decode request body: "+err.Error()))
 		return
 	}
 	if err := database.DB.Create(&apiKey).Error; err != nil {
-		utils.MakeHttpError(w, "failed to save api key: "+err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to save api key: "+err.Error()))
 		return
 	}
 	if err := json.NewEncoder(w).Encode(apiKey); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to encode response: "+err.Error()))
 		return
 	}
 }

--- a/packages/solver/internal/api/routes/api_key/delete.go
+++ b/packages/solver/internal/api/routes/api_key/delete.go
@@ -44,17 +44,17 @@ func DeleteRequest(w http.ResponseWriter, r *http.Request, _ *redis.Client, s *s
 
 	var apiKey models.ApiKey
 	if err := database.DB.First(&apiKey, "id = ?", id).Error; err != nil {
-		utils.MakeHttpError(w, "failed to find api key: "+err.Error(), http.StatusNotFound)
+		utils.RespondWithError(w, utils.ErrUnauthorized("api key does not exist"))
 		return
 	}
 
 	if err := database.DB.Delete(&apiKey).Error; err != nil {
-		utils.MakeHttpError(w, "failed to delete api key: "+err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to delete api key: "+err.Error()))
 		return
 	}
 
 	if err := json.NewEncoder(w).Encode(apiKey); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to encode response: "+err.Error()))
 		return
 	}
 }

--- a/packages/solver/internal/api/routes/api_key/read.go
+++ b/packages/solver/internal/api/routes/api_key/read.go
@@ -47,12 +47,12 @@ func ReadRequest(w http.ResponseWriter, r *http.Request, _ *redis.Client, s *sol
 
 	var apiKey models.ApiKey
 	if err := database.DB.First(&apiKey, "id = ?", id).Error; err != nil {
-		utils.MakeHttpError(w, "failed to find api key: "+err.Error(), http.StatusNotFound)
+		utils.RespondWithError(w, utils.ErrUnauthorized("api key does not exist"))
 		return
 	}
 
 	if err := json.NewEncoder(w).Encode(apiKey); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to encode response: "+err.Error()))
 		return
 	}
 }

--- a/packages/solver/internal/api/routes/api_key/update.go
+++ b/packages/solver/internal/api/routes/api_key/update.go
@@ -51,18 +51,18 @@ func UpdateRequest(w http.ResponseWriter, r *http.Request, _ *redis.Client, s *s
 
 	var apiKey models.ApiKey
 	if err := database.DB.First(&apiKey, "id = ?", id).Error; err != nil {
-		utils.MakeHttpError(w, "failed to find api key: "+err.Error(), http.StatusNotFound)
+		utils.RespondWithError(w, utils.ErrUnauthorized("api key does not exist"))
 		return
 	}
 
 	var newApiKey models.ApiKey
 	if err := json.NewDecoder(r.Body).Decode(&newApiKey); err != nil {
-		utils.MakeHttpError(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		utils.RespondWithError(w, utils.ErrInvalidRequestBody(err))
 		return
 	}
 
 	if err := database.DB.Model(&apiKey).Updates(newApiKey).Error; err != nil {
-		utils.MakeHttpError(w, "failed to update api key: "+err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to update api key: "+err.Error()))
 		return
 	}
 }

--- a/packages/solver/internal/api/routes/intent/get.go
+++ b/packages/solver/internal/api/routes/intent/get.go
@@ -158,7 +158,7 @@ func GetActionSchema(handler *actions.Protocol, protocol string, action string, 
 func GetRequest(w http.ResponseWriter, r *http.Request, c *redis.Client, s *solver.Solver) {
 	var params SchemaQueryParams
 	if err := Decoder.Decode(&params, r.URL.Query()); err != nil {
-		utils.MakeHttpError(w, fmt.Sprintf("invalid parameters: %v", err), http.StatusBadRequest)
+		utils.RespondWithError(w, utils.ErrInvalidParameters(err))
 		return
 	}
 
@@ -174,16 +174,16 @@ func GetRequest(w http.ResponseWriter, r *http.Request, c *redis.Client, s *solv
 	case exists && params.Action != "":
 		result, err = GetActionSchema(&protocol, params.Protocol, params.Action, params.ChainId, params.From, params.Search)
 	default:
-		utils.MakeHttpError(w, "invalid protocol", http.StatusBadRequest)
+		utils.RespondWithError(w, utils.ErrInvalidField("protocol", params.Protocol))
 		return
 	}
 	if err != nil {
-		utils.MakeHttpError(w, err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, err)
 		return
 	}
 
 	if err := json.NewEncoder(w).Encode(result); err != nil {
-		utils.MakeHttpError(w, "failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to encode response: "+err.Error()))
 		return
 	}
 }

--- a/packages/solver/internal/api/routes/intent/post.go
+++ b/packages/solver/internal/api/routes/intent/post.go
@@ -44,7 +44,7 @@ func PostContext(oc openapi.OperationContext) error {
 func PostRequest(w http.ResponseWriter, r *http.Request, c *redis.Client, s *solver.Solver) {
 	var intent *models.Intent
 	if err := json.NewDecoder(r.Body).Decode(&intent); err != nil {
-		utils.MakeHttpError(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		utils.RespondWithError(w, utils.ErrInvalidRequestBody(err))
 		return
 	}
 
@@ -53,15 +53,15 @@ func PostRequest(w http.ResponseWriter, r *http.Request, c *redis.Client, s *sol
 
 	intent, err = intent.GetOrCreate(database.DB)
 	if err != nil {
-		utils.MakeHttpError(w, "failed to initialize intent: "+err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to initialize intent: "+err.Error()))
 		return
 	}
 
 	if solution, err := s.Solve(intent, true, false); err != nil {
-		utils.MakeHttpError(w, err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to solve intent: "+err.Error()))
 	} else {
 		if err := json.NewEncoder(w).Encode(solution); err != nil {
-			utils.MakeHttpError(w, "failed to encode response: "+err.Error(), http.StatusInternalServerError)
+			utils.RespondWithError(w, utils.ErrInternal("failed to encode response: "+err.Error()))
 		}
 	}
 }

--- a/packages/solver/internal/api/routes/save/delete.go
+++ b/packages/solver/internal/api/routes/save/delete.go
@@ -1,6 +1,7 @@
 package save
 
 import (
+	"fmt"
 	"net/http"
 	"solver/internal/api/routes"
 	"solver/internal/database"
@@ -43,12 +44,12 @@ func DeleteRequest(w http.ResponseWriter, r *http.Request, _ *redis.Client, s *s
 
 	var intent models.Intent
 	if err := database.DB.First(&intent, "id = ?", id).Error; err != nil {
-		utils.MakeHttpError(w, "failed to find intent: "+err.Error(), http.StatusNotFound)
+		utils.RespondWithError(w, utils.ErrNotFound(fmt.Sprintf("failed to find intent with id: %s", err.Error())))
 		return
 	}
 
 	if err := database.DB.Delete(&intent).Error; err != nil {
-		utils.MakeHttpError(w, "failed to delete intent: "+err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to delete intent: "+err.Error()))
 		return
 	}
 

--- a/packages/solver/internal/api/routes/save/read.go
+++ b/packages/solver/internal/api/routes/save/read.go
@@ -55,13 +55,13 @@ func ReadRequest(w http.ResponseWriter, r *http.Request, _ *redis.Client, s *sol
 		Order("created_at desc").
 		Find(&intents)
 	if result.Error != nil {
-		utils.MakeHttpError(w, "database error: "+result.Error.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("database error: "+result.Error.Error()))
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(intents); err != nil {
-		utils.MakeHttpError(w, "Failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to encode response: "+err.Error()))
 		return
 	}
 }

--- a/packages/solver/internal/api/routes/save/toggle_saved.go
+++ b/packages/solver/internal/api/routes/save/toggle_saved.go
@@ -2,6 +2,7 @@ package save
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"solver/internal/api/routes"
 	"solver/internal/database"
@@ -44,14 +45,14 @@ func ToggleSavedRequest(w http.ResponseWriter, r *http.Request, _ *redis.Client,
 
 	var intent models.Intent
 	if err := database.DB.First(&intent, "id = ?", id).Error; err != nil {
-		utils.MakeHttpError(w, "failed to find intent: "+err.Error(), http.StatusNotFound)
+		utils.RespondWithError(w, utils.ErrNotFound(fmt.Sprintf("failed to find intent with id: %s", err.Error())))
 		return
 	}
 
 	intent.Saved = !intent.Saved
 
 	if err := database.DB.Select("saved").Updates(&intent).Error; err != nil {
-		utils.MakeHttpError(w, "failed to toggle intent: "+err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to toggle intent: "+err.Error()))
 		return
 	}
 

--- a/packages/solver/internal/api/routes/save/toggle_status.go
+++ b/packages/solver/internal/api/routes/save/toggle_status.go
@@ -2,6 +2,7 @@ package save
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"solver/internal/api/routes"
 	"solver/internal/database"
@@ -44,7 +45,7 @@ func ToggleStatusRequest(w http.ResponseWriter, r *http.Request, _ *redis.Client
 
 	var intent models.Intent
 	if err := database.DB.First(&intent, "id = ?", id).Error; err != nil {
-		utils.MakeHttpError(w, "failed to find intent: "+err.Error(), http.StatusNotFound)
+		utils.RespondWithError(w, utils.ErrNotFound(fmt.Sprintf("failed to find intent with id: %s", err.Error())))
 		return
 	}
 
@@ -55,7 +56,7 @@ func ToggleStatusRequest(w http.ResponseWriter, r *http.Request, _ *redis.Client
 	}
 
 	if err := database.DB.Select("status").Updates(&intent).Error; err != nil {
-		utils.MakeHttpError(w, "failed to toggle intent: "+err.Error(), http.StatusInternalServerError)
+		utils.RespondWithError(w, utils.ErrInternal("failed to toggle intent: "+err.Error()))
 		return
 	}
 

--- a/packages/solver/internal/utils/errors.go
+++ b/packages/solver/internal/utils/errors.go
@@ -2,66 +2,183 @@ package utils
 
 import (
 	"fmt"
+	"net/http"
 )
 
-type ServerError struct {
-	Message string `json:"message"`
-	Field   string `json:"status,omitempty"`
+// TODO: Mason -- what is field doing here exactly? Think I can rip it out but I see how it might help make defining the error message easier.
+type SolverError struct {
+	Message    string `json:"message"`
+	Field      string `json:"status,omitempty"`
+	Type       string `json:"type,omitempty"`
+	StatusCode int    `json:"-"`
 }
 
-func (e ServerError) Error() string {
+func (e SolverError) Error() string {
 	if e.Field != "" {
 		return fmt.Sprintf("%s: %s", e.Field, e.Message)
 	}
 	return e.Message
 }
 
+func (e SolverError) GetStatusCode() int {
+	if e.StatusCode == 0 {
+		return http.StatusInternalServerError
+	}
+	return e.StatusCode
+}
+
 var (
-	ErrEnvironmentNotInitialized = func(error string) ServerError {
-		return ServerError{Message: fmt.Sprintf("loading environment (.env) failed: %s", error)}
+	ErrEnvironmentNotInitialized = func(error string) SolverError {
+		return SolverError{
+			Type:    "EnvironmentNotInitialized",
+			Message: fmt.Sprintf("loading environment (.env) failed: %s", error),
+		}
 	}
 
-	ErrEnvironmentVarNotSet = func(envVar string) ServerError {
-		return ServerError{Message: fmt.Sprintf("%s environment variable not set.", envVar)}
+	ErrEnvironmentVarNotSet = func(envVar string) SolverError {
+		return SolverError{
+			Type:    "EnvironmentVarNotSet",
+			Message: fmt.Sprintf("%s environment variable not set.", envVar),
+		}
 	}
 
-	ErrEthClient = func(error string) ServerError {
-		return ServerError{Message: fmt.Sprintf("failed to connect to Ethereum node: %s", error)}
+	ErrEthClient = func(error string) SolverError {
+		return SolverError{
+			Type:    "EthClient",
+			Message: fmt.Sprintf("failed to connect to Ethereum node: %s", error),
+		}
 	}
 
-	ErrExplorer = func(error string) ServerError {
-		return ServerError{Message: fmt.Sprintf("failed to connect to Etherscan: %s", error)}
+	ErrExplorer = func(error string) SolverError {
+		return SolverError{
+			Type:    "Explorer",
+			Message: fmt.Sprintf("failed to connect to Etherscan: %s", error),
+		}
 	}
 
-	ErrABI = func(contractName string) ServerError {
-		return ServerError{Message: fmt.Sprintf("Contract %s could not be interfaced with.", contractName)}
+	ErrABI = func(contractName string) SolverError {
+		return SolverError{
+			Type:    "ABI",
+			Message: fmt.Sprintf("Contract %s could not be interfaced with.", contractName),
+		}
 	}
 
-	ErrContract = func(address string) ServerError {
-		return ServerError{Message: fmt.Sprintf("Contract at %s could not be interfaced with.", address)}
+	ErrContract = func(address string) SolverError {
+		return SolverError{
+			Type:    "Contract",
+			Message: fmt.Sprintf("Contract at %s could not be interfaced with.", address),
+		}
 	}
 
-	ErrBuild = func(error string) ServerError {
-		return ServerError{Message: fmt.Sprintf("Building transaction failed: %s", error)}
+	ErrBuild = func(error string) SolverError {
+		return SolverError{
+			Type:    "Build",
+			Message: fmt.Sprintf("Building transaction failed: %s", error),
+		}
 	}
 
-	ErrOptions = func(error string) ServerError {
-		return ServerError{Message: fmt.Sprintf("Building options failed: %s", error)}
+	ErrOptions = func(error string) SolverError {
+		return SolverError{
+			Type:    "Options",
+			Message: fmt.Sprintf("Building options failed: %s", error),
+		}
 	}
 
-	ErrTransaction = func(error string) ServerError {
-		return ServerError{Message: fmt.Sprintf("Building transaction failed: %s", error)}
+	ErrTransaction = func(error string) SolverError {
+		return SolverError{
+			Type:    "Transaction",
+			Message: fmt.Sprintf("Building transaction failed: %s", error),
+		}
 	}
 
-	ErrField = func(field string, message string) ServerError {
-		return ServerError{Field: field, Message: message}
+	ErrChainId = func(field string, value uint64) SolverError {
+		return SolverError{
+			Type:       "ChainId",
+			Field:      field,
+			Message:    fmt.Sprintf("%d is not a valid chainId", value),
+			StatusCode: http.StatusBadRequest,
+		}
 	}
 
-	ErrChainId = func(field string, value uint64) ServerError {
-		return ServerError{Field: field, Message: fmt.Sprintf("%d is not a valid chainId", value)}
+	ErrNotImplemented = func(message string) SolverError {
+		return SolverError{
+			Type:       "NotImplemented",
+			Message:    message,
+			StatusCode: http.StatusNotImplemented,
+		}
 	}
 
-	ErrNotImplemented = func(message string) ServerError { 
-		return ServerError{Message: message }
+	ErrMissingField = func(field string) SolverError {
+		return SolverError{
+			Type:       "MissingField",
+			Field:      field,
+			Message:    fmt.Sprintf("request missing required field: %s", field),
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	ErrUnauthorized = func(message string) SolverError {
+		return SolverError{
+			Type:       "Unauthorized",
+			Message:    message,
+			StatusCode: http.StatusUnauthorized,
+		}
+	}
+
+	ErrInvalidRequestBody = func(err error) SolverError {
+		return SolverError{
+			Type:       "InvalidRequestBody",
+			Message:    fmt.Sprintf("invalid request body: %v", err),
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	ErrNotFound = func(message string) SolverError {
+		return SolverError{
+			Type:       "NotFound",
+			Message:    message,
+			StatusCode: http.StatusNotFound,
+		}
+	}
+
+	ErrInvalidField = func(field string, value string) SolverError {
+		return SolverError{
+			Type:       "InvalidField",
+			Field:      field,
+			Message:    fmt.Sprintf("invalid value for field %s: %s", field, value),
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	ErrInvalidParameters = func(err error) SolverError {
+		return SolverError{
+			Type:       "InvalidParameters",
+			Message:    fmt.Sprintf("invalid parameters: %v", err),
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	ErrInternal = func(message string) SolverError {
+		return SolverError{
+			Type:       "InternalServerError",
+			Message:    message,
+			StatusCode: http.StatusInternalServerError,
+		}
 	}
 )
+
+// Helper function to check if an error is a SolverError and of a specific type
+func IsErrorOfType(err error, errorType string) bool {
+	if serverErr, ok := err.(SolverError); ok {
+		return serverErr.Type == errorType
+	}
+	return false
+}
+
+// Helper function to get the status code from any error
+func GetStatusCodeFromError(err error) int {
+	if serverErr, ok := err.(SolverError); ok {
+		return serverErr.GetStatusCode()
+	}
+	return http.StatusInternalServerError // Default to 500
+}


### PR DESCRIPTION
Hit an infrastructure hiccup where we were always returning a 500 error even if it's a client issue due to the error not surfacing until further down in the stack.

This refactor of the error system allows us to further standardize our errors and define http response details without being in the route handler.

Found this issue when I was fixing the "Require from in the GetSchema request if the action is user specific". We didn't know if the action was user specific until much further in the call stack and needed to change the http response when we were deep in it